### PR TITLE
Hwm and linger defines

### DIFF
--- a/cpp/data/common/include/EigerDefinitions.h
+++ b/cpp/data/common/include/EigerDefinitions.h
@@ -45,6 +45,7 @@ namespace Eiger {
   const int MORE_MESSAGES = 1;
   const int RECEIVE_HWM = 100000;
   const int SEND_HWM = 100000;
+  const int LINGER_TIMEOUT = 100;  // Socket linger timeout in milliseconds
 
   const std::string CONTROL_CMD_KEY = "msg_val";
   const std::string CONTROL_ID_KEY = "id";

--- a/cpp/data/common/include/EigerDefinitions.h
+++ b/cpp/data/common/include/EigerDefinitions.h
@@ -45,7 +45,7 @@ namespace Eiger {
   const int MORE_MESSAGES = 1;
   const int RECEIVE_HWM = 100000;  // High water marks for the main receiver thread
   const int SEND_HWM = 100000;
-  const int WORKER_SEND_HWM = 10000;  // A lower high water mark for the worker threads
+  const int WORKER_HWM = 10000;  // A lower high water mark for the worker threads
   const int LINGER_TIMEOUT = 100;  // Socket linger timeout in milliseconds
 
   const std::string CONTROL_CMD_KEY = "msg_val";

--- a/cpp/data/common/include/EigerDefinitions.h
+++ b/cpp/data/common/include/EigerDefinitions.h
@@ -43,8 +43,9 @@ namespace Eiger {
 
   // EigerFan related constants
   const int MORE_MESSAGES = 1;
-  const int RECEIVE_HWM = 100000;
+  const int RECEIVE_HWM = 100000;  // High water marks for the main receiver thread
   const int SEND_HWM = 100000;
+  const int WORKER_SEND_HWM = 10000;  // A lower high water mark for the worker threads
   const int LINGER_TIMEOUT = 100;  // Socket linger timeout in milliseconds
 
   const std::string CONTROL_CMD_KEY = "msg_val";

--- a/cpp/data/eigerfan/src/EigerFan.cpp
+++ b/cpp/data/eigerfan/src/EigerFan.cpp
@@ -363,8 +363,6 @@ void EigerFan::HandleRxSocket(std::string& endpoint, int num_zmq_context_threads
   zmq::socket_t rx_socket(inproc_context, ZMQ_PULL);
   rx_socket.setsockopt(ZMQ_RCVHWM, &RECEIVE_HWM, sizeof(RECEIVE_HWM));
   rx_socket.bind(BROKER_INPROC_ENDPOINT.c_str());
-  int hwm = 100000;
-  rx_socket.setsockopt(ZMQ_RCVHWM, &hwm, sizeof(hwm));
   int linger = 100;
   rx_socket.setsockopt(ZMQ_LINGER, &linger, sizeof(linger));
   this->broker.connect(endpoint, &inproc_context);

--- a/cpp/data/eigerfan/src/MultiPullBroker.cpp
+++ b/cpp/data/eigerfan/src/MultiPullBroker.cpp
@@ -54,7 +54,7 @@ void MultiPullBroker::worker_loop(std::string& endpoint) {
   // threads on the context is not sufficient.
   zmq::context_t source_context(1);
   zmq::socket_t source_socket(source_context, ZMQ_PULL);
-  source_socket.setsockopt(ZMQ_SNDHWM, &SEND_HWM, sizeof(SEND_HWM));
+  source_socket.setsockopt(ZMQ_SNDHWM, &WORKER_SEND_HWM, sizeof(WORKER_SEND_HWM));
   source_socket.setsockopt(ZMQ_LINGER, &LINGER_TIMEOUT, sizeof(LINGER_TIMEOUT));
   source_socket.connect(endpoint.c_str());
 
@@ -62,7 +62,7 @@ void MultiPullBroker::worker_loop(std::string& endpoint) {
   // The sink sockets must use the context from the main thread to use the inproc://
   // protocol. If it uses a different context the client will not see the messages.
   zmq::socket_t sink_socket(*this->inproc_context_, ZMQ_PUSH);
-  sink_socket.setsockopt(ZMQ_SNDHWM, &SEND_HWM, sizeof(SEND_HWM));
+  sink_socket.setsockopt(ZMQ_SNDHWM, &WORKER_SEND_HWM, sizeof(WORKER_SEND_HWM));
   sink_socket.setsockopt(ZMQ_LINGER, &LINGER_TIMEOUT, sizeof(LINGER_TIMEOUT));
   sink_socket.connect(this->sink_endpoint_.c_str());
 

--- a/cpp/data/eigerfan/src/MultiPullBroker.cpp
+++ b/cpp/data/eigerfan/src/MultiPullBroker.cpp
@@ -54,7 +54,7 @@ void MultiPullBroker::worker_loop(std::string& endpoint) {
   // threads on the context is not sufficient.
   zmq::context_t source_context(1);
   zmq::socket_t source_socket(source_context, ZMQ_PULL);
-  source_socket.setsockopt(ZMQ_SNDHWM, &WORKER_SEND_HWM, sizeof(WORKER_SEND_HWM));
+  source_socket.setsockopt(ZMQ_SNDHWM, &WORKER_HWM, sizeof(WORKER_HWM));
   source_socket.setsockopt(ZMQ_LINGER, &LINGER_TIMEOUT, sizeof(LINGER_TIMEOUT));
   source_socket.connect(endpoint.c_str());
 
@@ -62,7 +62,7 @@ void MultiPullBroker::worker_loop(std::string& endpoint) {
   // The sink sockets must use the context from the main thread to use the inproc://
   // protocol. If it uses a different context the client will not see the messages.
   zmq::socket_t sink_socket(*this->inproc_context_, ZMQ_PUSH);
-  sink_socket.setsockopt(ZMQ_SNDHWM, &WORKER_SEND_HWM, sizeof(WORKER_SEND_HWM));
+  sink_socket.setsockopt(ZMQ_SNDHWM, &WORKER_HWM, sizeof(WORKER_HWM));
   sink_socket.setsockopt(ZMQ_LINGER, &LINGER_TIMEOUT, sizeof(LINGER_TIMEOUT));
   sink_socket.connect(this->sink_endpoint_.c_str());
 

--- a/cpp/data/eigerfan/src/MultiPullBroker.cpp
+++ b/cpp/data/eigerfan/src/MultiPullBroker.cpp
@@ -47,7 +47,6 @@ void MultiPullBroker::connect(std::string& endpoint, void* inproc_context) {
  * \param[in] endpoint Endpoint of socket to pull data from
  */
 void MultiPullBroker::worker_loop(std::string& endpoint) {
-  int linger = 100;
 
   // Create source in new isolated context
   // It is important to create a new context in each worker thread, as there are
@@ -56,7 +55,7 @@ void MultiPullBroker::worker_loop(std::string& endpoint) {
   zmq::context_t source_context(1);
   zmq::socket_t source_socket(source_context, ZMQ_PULL);
   source_socket.setsockopt(ZMQ_SNDHWM, &SEND_HWM, sizeof(SEND_HWM));
-  source_socket.setsockopt(ZMQ_LINGER, &linger, sizeof(linger));
+  source_socket.setsockopt(ZMQ_LINGER, &LINGER_TIMEOUT, sizeof(LINGER_TIMEOUT));
   source_socket.connect(endpoint.c_str());
 
   // Create sink socket in context of main thread
@@ -64,7 +63,7 @@ void MultiPullBroker::worker_loop(std::string& endpoint) {
   // protocol. If it uses a different context the client will not see the messages.
   zmq::socket_t sink_socket(*this->inproc_context_, ZMQ_PUSH);
   sink_socket.setsockopt(ZMQ_SNDHWM, &SEND_HWM, sizeof(SEND_HWM));
-  sink_socket.setsockopt(ZMQ_LINGER, &linger, sizeof(linger));
+  sink_socket.setsockopt(ZMQ_LINGER, &LINGER_TIMEOUT, sizeof(LINGER_TIMEOUT));
   sink_socket.connect(this->sink_endpoint_.c_str());
 
   // Initialise recv variables

--- a/cpp/data/eigerfan/src/MultiPullBroker.cpp
+++ b/cpp/data/eigerfan/src/MultiPullBroker.cpp
@@ -47,7 +47,6 @@ void MultiPullBroker::connect(std::string& endpoint, void* inproc_context) {
  * \param[in] endpoint Endpoint of socket to pull data from
  */
 void MultiPullBroker::worker_loop(std::string& endpoint) {
-  int hwm = 10000;
   int linger = 100;
 
   // Create source in new isolated context
@@ -56,7 +55,7 @@ void MultiPullBroker::worker_loop(std::string& endpoint) {
   // threads on the context is not sufficient.
   zmq::context_t source_context(1);
   zmq::socket_t source_socket(source_context, ZMQ_PULL);
-  source_socket.setsockopt(ZMQ_SNDHWM, &hwm, sizeof(hwm));
+  source_socket.setsockopt(ZMQ_SNDHWM, &SEND_HWM, sizeof(SEND_HWM));
   source_socket.setsockopt(ZMQ_LINGER, &linger, sizeof(linger));
   source_socket.connect(endpoint.c_str());
 
@@ -64,7 +63,7 @@ void MultiPullBroker::worker_loop(std::string& endpoint) {
   // The sink sockets must use the context from the main thread to use the inproc://
   // protocol. If it uses a different context the client will not see the messages.
   zmq::socket_t sink_socket(*this->inproc_context_, ZMQ_PUSH);
-  sink_socket.setsockopt(ZMQ_SNDHWM, &hwm, sizeof(hwm));
+  sink_socket.setsockopt(ZMQ_SNDHWM, &SEND_HWM, sizeof(SEND_HWM));
   sink_socket.setsockopt(ZMQ_LINGER, &linger, sizeof(linger));
   sink_socket.connect(this->sink_endpoint_.c_str());
 


### PR DESCRIPTION
These changes are to address the two remaining magic numbers - hwm and linger

SEND_HWM was already defined within EigerDefinitions.h and used in the codebase, so I could just use this in place of the remaining local hwm variables.

For the linger I introduced LINGER_TIMEOUT in EigerDefinitions.h and used that in place of local linger variables